### PR TITLE
Update example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,15 @@
     <groupId>net.opacapp</groupId>
     <artifactId>libopac-sample</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>net.opacapp</groupId>
             <artifactId>libopac</artifactId>
-            <version>4.5.0-rc-1</version>
+            <version>6.3.8</version>
             <scope>compile</scope>
             <type>jar</type>
         </dependency>
@@ -28,7 +32,7 @@
             </snapshots>
             <id>central</id>
             <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
 </project>

--- a/src/main/java/net/opacapp/sample/libopacmvn/HelloOpac.java
+++ b/src/main/java/net/opacapp/sample/libopacmvn/HelloOpac.java
@@ -2,7 +2,7 @@ package net.opacapp.sample.libopacmvn;
 
 import de.geeksfactory.opacclient.OpacApiFactory;
 import de.geeksfactory.opacclient.apis.OpacApi;
-import de.geeksfactory.opacclient.objects.DetailledItem;
+import de.geeksfactory.opacclient.objects.DetailedItem;
 import de.geeksfactory.opacclient.objects.Library;
 import de.geeksfactory.opacclient.objects.SearchRequestResult;
 import de.geeksfactory.opacclient.searchfields.SearchField;
@@ -17,7 +17,7 @@ import java.util.List;
 public class HelloOpac {
 
     public static String LIBRARY_NAME = "Bremen";
-    public static String LIBRARY_CONFIG = "{\"account_supported\":true,\"api\":\"sisis\",\"city\":\"Bremen\",\"country\":\"Deutschland\",\"data\":{\"baseurl\":\"https://opac.stadtbibliothek-bremen.de/webOPACClient\"},\"geo\":[53.07929619999999,8.8016937],\"information\":\"http://www.stadtbibliothek-bremen.de/bibliotheken.php\",\"replacedby\":\"de.opacapp.bremen\",\"state\":\"Bremen\",\"title\":\"Stadtbibliothek\"}";
+    public static String LIBRARY_CONFIG = "{\"account_supported\":true,\"api\":\"sisis\",\"city\":\"Bremen\",\"country\":\"Deutschland\",\"data\":{\"baseurl\":\"https://opac.stabi-hb.de/webOPACClient\"},\"geo\":[53.07929619999999,8.8016937],\"information\":\"http://www.stadtbibliothek-bremen.de/bibliotheken.php\",\"replacedby\":\"de.opacapp.bremen\",\"state\":\"Bremen\",\"title\":\"Stadtbibliothek\"}";
 
     public static void main(final String[] args) throws JSONException, OpacApi.OpacErrorException, IOException {
         System.out.println("Hello OPAC!");
@@ -42,7 +42,7 @@ public class HelloOpac {
         System.out.println("First match: " + searchRequestResult.getResults().get(0).toString());
 
         System.out.println("Fetching details for the first result...");
-        DetailledItem detailledItem = api.getResult(0);
+        DetailedItem detailledItem = api.getResult(0);
         System.out.println("Got details: " + detailledItem.toString());
     }
 }


### PR DESCRIPTION
- fix library url to avoid SSLPeerUnverifiedException
- update libopac version and fix DetailedItem class name
- specify java source and target to avoid errors like "Source option 5
  is no longer supported. Use 6 or later." See documentation at
  https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html
- update jcenter url

This addresses #1.